### PR TITLE
Add WorkOS to SCIM 2.0 implementations list

### DIFF
--- a/public/json/scim_v2_implementations.json
+++ b/public/json/scim_v2_implementations.json
@@ -416,6 +416,14 @@ const scim_v2_implementations = {
             "developer": "Ping Identity (acquirer of UnboundID)",
             "link": "https://github.com/pingidentity/scim2"
         },
+	{
+            "project_name": "WorkOS",
+            "client": "No",
+            "server": "Yes",
+            "open_source": "No",
+            "developer": "WorkOS, Inc.",
+            "link": "https://workos.com/docs/directory-sync?utm_source=scim_cloud"
+        },
         {
             "project_name": "WSO2 Charon",
             "client": "Yes",


### PR DESCRIPTION
The team at WorkOS is looking to get our SCIM 2.0 implementation added to the list. Thanks!

More details available in our [docs](https://workos.com/docs/directory-sync?utm_source=scim_cloud).