### PR TITLE
add scim2-models to the implementation list

### DIFF
--- a/public/json/scim_v2_implementations.json
+++ b/public/json/scim_v2_implementations.json
@@ -393,6 +393,14 @@ const scim_v2_implementations = {
             "link": "https://github.com/Will-Low/scimterface"
         },
         {
+            "project_name": "scim2-models",
+            "client": "Yes",
+            "server": "Yes",
+            "open_source": "Yes, Apache License",
+            "developer": "Yaal Coop",
+            "link": "https://github.com/yaal-coop/scim2-models"
+        },
+        {
             "project_name": "SimpleIdentityServer",
             "client": "Yes",
             "server": "Yes",


### PR DESCRIPTION
Add https://github.com/python-scim/scim2-models to the list of implementations.

